### PR TITLE
Compatibility for SQLAlchemy 0.8

### DIFF
--- a/sqlalchemy_tree/options.py
+++ b/sqlalchemy_tree/options.py
@@ -256,6 +256,10 @@ class TreeOptions(object):
       if (getattr(prop, 'remote_side', None) is not None and
           getattr(prop.remote_side, 'name', None) == self.pk_field.name):
         return prop.key
+      # Above test works for SQLAlchemy 0.7, the one below for 0.8
+      if (len(getattr(prop, 'remote_side', [])) == 1 and
+          self.pk_field in prop.remote_side):
+        return prop.key
     raise ValueError, \
       u"could not auto-detect parent field name; tree extension will not " \
       u"work property without a parent relationship defined"


### PR DESCRIPTION
The check for the parent field name failed for SQLAlchemy 0.8 and
a second test for that version was introduced. The code works for
both >=0.7.5 and >=0.8 versions now.
