### PR TITLE
Don't cover `tests/__init__`, `__init__`, `__about__` or `_compat`.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,10 @@
 [run]
 omit =
-    */test/*
+    */tests/__init__.py
+    */_compat.py
+    */__init__.py
+    */__about__.py
+
 
 [report]
 exclude_lines =


### PR DESCRIPTION
This will bump our coverage up.
